### PR TITLE
feat: Add context menu to ribbon icon

### DIFF
--- a/helpers/reset.ts
+++ b/helpers/reset.ts
@@ -5,11 +5,51 @@ import {
 	foldersToBatches,
 	getSyncMessage,
 } from "./drive";
-import { Notice, TAbstractFile, TFile, TFolder } from "obsidian";
+import {
+	Notice,
+	TAbstractFile,
+	TFile,
+	TFolder,
+	Modal,
+	Setting,
+} from "obsidian";
 import { pull } from "./pull";
+
+export class ConfirmResetModal extends Modal {
+	constructor(t: ObsidianGoogleDrive, proceed: (res: boolean) => void) {
+		super(t.app);
+		this.setTitle(
+			"Are you sure you want to reset the data from Google Drive?"
+		);
+		this.setContent(
+			"You'll loose all the local changes to your data and load only the information on your google drive. This step is irreversible."
+		);
+		new Setting(this.contentEl)
+			.addButton((btn) =>
+				btn
+					.setWarning()
+					.setButtonText("RESET!")
+					.onClick(() => {
+						this.close();
+						proceed(true);
+					})
+			)
+			.addButton((btn) =>
+				btn.setButtonText("Cancel").onClick(() => {
+					this.close();
+					proceed(false);
+				})
+			);
+	}
+}
 
 export const reset = async (t: ObsidianGoogleDrive) => {
 	if (t.syncing) return;
+
+	const proceed = await new Promise<boolean>((resolve) => {
+		new ConfirmResetModal(t, resolve).open();
+	});
+	if (!proceed) return;
 
 	const syncNotice = await t.startSync();
 

--- a/helpers/reset.ts
+++ b/helpers/reset.ts
@@ -16,8 +16,11 @@ import {
 import { pull } from "./pull";
 
 export class ConfirmResetModal extends Modal {
+	proceed: (res: boolean) => void;
 	constructor(t: ObsidianGoogleDrive, proceed: (res: boolean) => void) {
 		super(t.app);
+		this.proceed = proceed;
+
 		this.setTitle(
 			"Are you sure you want to reset the data from Google Drive?"
 		);
@@ -26,20 +29,20 @@ export class ConfirmResetModal extends Modal {
 		);
 		new Setting(this.contentEl)
 			.addButton((btn) =>
-				btn
-					.setWarning()
-					.setButtonText("RESET!")
-					.onClick(() => {
-						this.close();
-						proceed(true);
-					})
+				btn.setButtonText("Cancel").onClick(() => this.close())
 			)
 			.addButton((btn) =>
-				btn.setButtonText("Cancel").onClick(() => {
-					this.close();
-					proceed(false);
-				})
+				btn
+					.setButtonText("RESET!")
+					.setWarning()
+					.onClick(() => {
+						proceed(true);
+						this.close();
+					})
 			);
+	}
+	onClose() {
+		this.proceed(false);
 	}
 }
 

--- a/main.ts
+++ b/main.ts
@@ -13,6 +13,7 @@ import {
 	Setting,
 	TAbstractFile,
 	TFile,
+	Menu,
 } from "obsidian";
 
 interface PluginSettings {
@@ -58,8 +59,29 @@ export default class ObsidianGoogleDrive extends Plugin {
 
 		this.ribbonIcon = this.addRibbonIcon(
 			"refresh-cw",
-			"Push to Google Drive",
-			() => push(this)
+			"Obsidian Google Drive",
+			(event) => {
+				const menu = new Menu();
+
+				menu.addItem((item) =>
+					item
+						.setTitle("Pull from Drive")
+						.setIcon("cloud-download")
+						.onClick(() => {
+							pull(this);
+						})
+				);
+
+				menu.addItem((item) =>
+					item
+						.setTitle("Push to Drive")
+						.setIcon("cloud-upload")
+						.onClick(() => {
+							push(this);
+						})
+				);
+				menu.showAtMouseEvent(event)
+			}
 		);
 
 		this.addCommand({

--- a/main.ts
+++ b/main.ts
@@ -32,35 +32,6 @@ const DEFAULT_SETTINGS: PluginSettings = {
 	changesToken: "",
 };
 
-export class ConfirmModal extends Modal {
-	constructor(
-		app: App,
-		title: string,
-		text: string,
-		buttonText: string,
-		onSubmit: (doIt: boolean) => void
-	) {
-		super(app);
-		this.setTitle(title);
-		this.setContent(text);
-		new Setting(this.contentEl)
-			.addButton((btn) =>
-				btn
-					.setWarning()
-					.setButtonText(buttonText)
-					.onClick(() => {
-						this.close();
-						onSubmit(true);
-					})
-			)
-			.addButton((btn) =>
-				btn.setButtonText("Cancel").onClick(() => {
-					this.close();
-					onSubmit(false);
-				})
-			);
-	}
-}
 export default class ObsidianGoogleDrive extends Plugin {
 	settings: PluginSettings;
 	accessToken = {
@@ -90,6 +61,7 @@ export default class ObsidianGoogleDrive extends Plugin {
 			"refresh-cw",
 			"Obsidian Google Drive",
 			(event) => {
+				if (this.syncing) return;
 				const menu = new Menu();
 
 				menu.addItem((item) =>
@@ -114,18 +86,7 @@ export default class ObsidianGoogleDrive extends Plugin {
 						.setTitle("Reset from Drive")
 						.setIcon("triangle-alert")
 						.onClick(() => {
-							new ConfirmModal(
-								this.app,
-								"Are you sure you want to reset the data from Google Drive?",
-								"You'll loose all the local changes to your data and load only the information on your google drive. This step is irreversible.",
-								"RESET!",
-								(doIt) => {
-									if (doIt) {
-										reset(this);
-									}
-									return;
-								}
-							).open();
+							reset(this);
 						})
 				);
 				menu.showAtMouseEvent(event);

--- a/main.ts
+++ b/main.ts
@@ -6,7 +6,6 @@ import { reset } from "helpers/reset";
 import {
 	App,
 	debounce,
-	Modal,
 	Notice,
 	Plugin,
 	PluginSettingTab,

--- a/main.ts
+++ b/main.ts
@@ -32,6 +32,35 @@ const DEFAULT_SETTINGS: PluginSettings = {
 	changesToken: "",
 };
 
+export class ConfirmModal extends Modal {
+	constructor(
+		app: App,
+		title: string,
+		text: string,
+		buttonText: string,
+		onSubmit: (doIt: boolean) => void
+	) {
+		super(app);
+		this.setTitle(title);
+		this.setContent(text);
+		new Setting(this.contentEl)
+			.addButton((btn) =>
+				btn
+					.setWarning()
+					.setButtonText(buttonText)
+					.onClick(() => {
+						this.close();
+						onSubmit(true);
+					})
+			)
+			.addButton((btn) =>
+				btn.setButtonText("Cancel").onClick(() => {
+					this.close();
+					onSubmit(false);
+				})
+			);
+	}
+}
 export default class ObsidianGoogleDrive extends Plugin {
 	settings: PluginSettings;
 	accessToken = {
@@ -80,7 +109,26 @@ export default class ObsidianGoogleDrive extends Plugin {
 							push(this);
 						})
 				);
-				menu.showAtMouseEvent(event)
+				menu.addItem((item) =>
+					item
+						.setTitle("Reset from Drive")
+						.setIcon("triangle-alert")
+						.onClick(() => {
+							new ConfirmModal(
+								this.app,
+								"Are you sure you want to reset the data from Google Drive?",
+								"You'll loose all the local changes to your data and load only the information on your google drive. This step is irreversible.",
+								"RESET!",
+								(doIt) => {
+									if (doIt) {
+										reset(this);
+									}
+									return;
+								}
+							).open();
+						})
+				);
+				menu.showAtMouseEvent(event);
 			}
 		);
 

--- a/styles.css
+++ b/styles.css
@@ -47,3 +47,12 @@
 .operation-file {
 	overflow-wrap: break-word;
 }
+
+.reset-warning-modal{
+	--modal-border-color: var(--text-error);
+}
+
+.reset-warining-text{
+	color: var(--text-error);
+	font-weight: bolder;
+}


### PR DESCRIPTION
I've added a context menu into the ribbon icon.
![image](https://github.com/user-attachments/assets/117c7dfa-8679-47ae-ba13-45d37d563340)
Now you can push and pull from the same icon.