### PR TITLE
Fix sync filtering and long path metadata

### DIFF
--- a/helpers/drive.ts
+++ b/helpers/drive.ts
@@ -6,7 +6,7 @@ import { TAbstractFile, TFolder } from "obsidian";
 export interface FileMetadata {
 	id: string;
 	name: string;
-	description: string;
+	description?: string;
 	mimeType: string;
 	starred: boolean;
 	properties: Record<string, string>;
@@ -34,12 +34,103 @@ const BLACKLISTED_CONFIG_FILES = [
 	"workspace-mobile.json",
 ];
 
-const WHITELISTED_PLUGIN_FILES = [
-	"manifest.json",
-	"styles.css",
-	"main.js",
-	"data.json",
-];
+const WHITELISTED_PLUGIN_FILES = ["manifest.json", "styles.css", "main.js"];
+
+const GOOGLE_PROPERTY_VALUE_MAX_BYTES = 124;
+const PATH_DESCRIPTION_PREFIX = "Obsidian path: ";
+const textEncoder = new TextEncoder();
+const IGNORED_SEGMENTS = new Set([
+	".git",
+	".obsidian",
+	".trash",
+	".claude",
+	".claudian",
+	"node_modules",
+	"credentials",
+	"__pycache__",
+	"venv",
+	".venv",
+	"env",
+]);
+const SENSITIVE_PATH_PATTERN =
+	/(^|[\/._ -])(api[-_ ]?key|apikey|secret|token|credential)([\/._ -]|$)/i;
+
+const byteLength = (value: string) => textEncoder.encode(value).length;
+
+const hashPath = (path: string) => {
+	let hash = 2166136261;
+	for (let index = 0; index < path.length; index++) {
+		hash ^= path.charCodeAt(index);
+		hash = Math.imul(hash, 16777619);
+	}
+	return (hash >>> 0).toString(36);
+};
+
+export const isIgnoredPath = (path: string) => {
+	const normalized = path.replace(/^\/+|\/+$/g, "");
+	if (!normalized) return false;
+	const segments = normalized.split("/");
+	return (
+		segments.some((segment) => IGNORED_SEGMENTS.has(segment)) ||
+		segments.some(
+			(segment) => segment === ".DS_Store" || /^\.env($|\.)/.test(segment)
+		) ||
+		SENSITIVE_PATH_PATTERN.test(normalized)
+	);
+};
+
+export const dropOperationsForPath = (
+	operations: Record<string, string>,
+	path: string
+) => {
+	for (const operationPath of Object.keys(operations)) {
+		if (operationPath === path || operationPath.startsWith(path + "/")) {
+			delete operations[operationPath];
+		}
+	}
+};
+
+export const cleanIgnoredOperations = (operations: Record<string, string>) => {
+	let removed = 0;
+	for (const operationPath of Object.keys(operations)) {
+		if (isIgnoredPath(operationPath)) {
+			delete operations[operationPath];
+			removed++;
+		}
+	}
+	return removed;
+};
+
+export const metadataForPath = (
+	path: string,
+	properties: Record<string, string> = {}
+) => {
+	const nextProperties = { ...properties };
+	delete nextProperties.path;
+	if (byteLength(path) <= GOOGLE_PROPERTY_VALUE_MAX_BYTES) {
+		nextProperties.path = path;
+		return { properties: nextProperties };
+	}
+	return {
+		description: PATH_DESCRIPTION_PREFIX + path,
+		properties: {
+			...nextProperties,
+			pathKey: hashPath(path),
+		},
+	};
+};
+
+export const pathFromDriveFile = (
+	file: Pick<FileMetadata, "id" | "properties" | "description">,
+	driveIdToPath: Record<string, string>
+) => {
+	const description = file.description || "";
+	if (file.properties?.path) return file.properties.path;
+	if (driveIdToPath[file.id]) return driveIdToPath[file.id];
+	if (description.startsWith(PATH_DESCRIPTION_PREFIX)) {
+		return description.slice(PATH_DESCRIPTION_PREFIX.length);
+	}
+};
 
 const stringSearchToQuery = (search: StringSearch) => {
 	if (typeof search === "string") return `='${search}'`;
@@ -215,6 +306,11 @@ export const getDriveClient = (t: ObsidianGoogleDrive) => {
 		}
 
 		if (!properties) properties = {};
+		if (properties.path) {
+			const pathMetadata = metadataForPath(properties.path, properties);
+			properties = pathMetadata.properties;
+			description = description || pathMetadata.description;
+		}
 		if (!properties.vault) properties.vault = t.app.vault.getName();
 
 		const folder = await drive
@@ -246,8 +342,20 @@ export const getDriveClient = (t: ObsidianGoogleDrive) => {
 
 		if (!metadata) metadata = {};
 		if (!metadata.properties) metadata.properties = {};
-		if (!metadata.properties.vault) {
-			metadata.properties.vault = t.app.vault.getName();
+		if (metadata.properties.path) {
+			const pathMetadata = metadataForPath(
+				metadata.properties.path,
+				metadata.properties
+			);
+			metadata = {
+				...metadata,
+				description: metadata.description || pathMetadata.description,
+				properties: pathMetadata.properties,
+			};
+		}
+		const metadataProperties = metadata.properties as Record<string, string>;
+		if (!metadataProperties.vault) {
+			metadataProperties.vault = t.app.vault.getName();
 		}
 
 		const form = new FormData();

--- a/helpers/pull.ts
+++ b/helpers/pull.ts
@@ -6,6 +6,8 @@ import {
 	folderMimeType,
 	foldersToBatches,
 	getSyncMessage,
+	isIgnoredPath,
+	pathFromDriveFile,
 } from "./drive";
 import { refreshAccessToken } from "./ky";
 
@@ -26,7 +28,7 @@ export const pull = async (
 	if (!t.accessToken.token) await refreshAccessToken(t);
 
 	const recentlyModified = await t.drive.searchFiles({
-		include: ["id", "modifiedTime", "properties", "mimeType"],
+		include: ["id", "description", "modifiedTime", "properties", "mimeType"],
 		matches: [
 			{
 				modifiedTime: {
@@ -49,6 +51,10 @@ export const pull = async (
 		.map(({ fileId }) => {
 			const path = t.settings.driveIdToPath[fileId];
 			if (!path) return;
+			if (isIgnoredPath(path)) {
+				delete t.settings.driveIdToPath[fileId];
+				return;
+			}
 			delete t.settings.driveIdToPath[fileId];
 
 			const file = vault.getAbstractFileByPath(path);
@@ -71,8 +77,9 @@ export const pull = async (
 	);
 
 	const updateMap = () => {
-		recentlyModified.forEach(({ id, properties }) => {
-			pathToId[properties.path] = id;
+		recentlyModified.forEach((file) => {
+			const path = pathFromDriveFile(file, t.settings.driveIdToPath);
+			if (path && !isIgnoredPath(path)) pathToId[path] = file.id;
 		});
 
 		t.settings.driveIdToPath = Object.fromEntries(
@@ -127,23 +134,29 @@ export const pull = async (
 		);
 
 		if (newFolders.length) {
-			const batches = foldersToBatches(
-				newFolders.map(({ properties }) => properties.path)
-			);
-
-			for (const batch of batches) {
-				await Promise.all(
-					batch.map(async (folder) => {
-						delete t.settings.operations[folder];
-						if (
-							vault.getFolderByPath(folder) ||
-							(await adapter.exists(folder))
-						) {
-							return;
-						}
-						return t.createFolder(folder);
-					})
+			const newFolderPaths = newFolders
+				.map((file) => pathFromDriveFile(file, t.settings.driveIdToPath))
+				.filter(
+					(path): path is string => !!path && !isIgnoredPath(path)
 				);
+
+			if (newFolderPaths.length) {
+				const batches = foldersToBatches(newFolderPaths);
+
+				for (const batch of batches) {
+					await Promise.all(
+						batch.map(async (folder) => {
+							delete t.settings.operations[folder];
+							if (
+								vault.getFolderByPath(folder) ||
+								(await adapter.exists(folder))
+							) {
+								return;
+							}
+							return t.createFolder(folder);
+						})
+					);
+				}
 			}
 		}
 
@@ -155,10 +168,12 @@ export const pull = async (
 
 		await batchAsyncs(
 			newNotes.map((file: FileMetadata) => async () => {
+				const path = pathFromDriveFile(file, t.settings.driveIdToPath);
+				if (!path || isIgnoredPath(path)) return;
+
 				const localFile =
-					vault.getFileByPath(file.properties.path) ||
-					(await adapter.exists(file.properties.path));
-				const operation = t.settings.operations[file.properties.path];
+					vault.getFileByPath(path) || (await adapter.exists(path));
+				const operation = t.settings.operations[path];
 
 				completed++;
 
@@ -167,7 +182,7 @@ export const pull = async (
 				}
 
 				if (localFile && operation === "create") {
-					t.settings.operations[file.properties.path] = "modify";
+					t.settings.operations[path] = "modify";
 					return;
 				}
 
@@ -181,11 +196,7 @@ export const pull = async (
 					return t.modifyFile(localFile, content, file.modifiedTime);
 				}
 
-				return t.upsertFile(
-					file.properties.path,
-					content,
-					file.modifiedTime
-				);
+				return t.upsertFile(path, content, file.modifiedTime);
 			})
 		);
 	};
@@ -198,7 +209,13 @@ export const pull = async (
 				.filter(({ removed }) => removed)
 				.map(async ({ fileId }) => {
 					const path = t.settings.driveIdToPath[fileId];
-					if (!path || vault.getAbstractFileByPath(path)) return;
+					if (
+						!path ||
+						isIgnoredPath(path) ||
+						vault.getAbstractFileByPath(path)
+					) {
+						return;
+					}
 					const stat = await adapter.stat(path);
 					if (!stat) return;
 					return { path, type: stat.type };

--- a/helpers/push.ts
+++ b/helpers/push.ts
@@ -2,10 +2,12 @@ import ObsidianGoogleDrive from "main";
 import { Modal, Notice, setIcon, Setting, TFile, TFolder } from "obsidian";
 import {
 	batchAsyncs,
+	cleanIgnoredOperations,
 	fileNameFromPath,
 	folderMimeType,
 	foldersToBatches,
 	getSyncMessage,
+	isIgnoredPath,
 } from "./drive";
 import { pull } from "./pull";
 
@@ -242,9 +244,16 @@ class ConfirmUndoModal extends Modal {
 
 export const push = async (t: ObsidianGoogleDrive) => {
 	if (t.syncing) return;
+	if (cleanIgnoredOperations(t.settings.operations)) {
+		await t.saveSettings();
+	}
 	const initialOperations = Object.entries(t.settings.operations).sort(
 		([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)
 	); // Alphabetical
+
+	if (!initialOperations.length) {
+		return new Notice("No eligible changes to push.");
+	}
 
 	const { vault } = t.app;
 	const adapter = vault.adapter;
@@ -258,6 +267,7 @@ export const push = async (t: ObsidianGoogleDrive) => {
 	const syncNotice = await t.startSync();
 
 	await pull(t, true);
+	cleanIgnoredOperations(t.settings.operations);
 
 	const operations = Object.entries(t.settings.operations);
 
@@ -279,20 +289,30 @@ export const push = async (t: ObsidianGoogleDrive) => {
 
 	await Promise.all(
 		configOnDrive.map(async ({ properties }) => {
-			if (!(await adapter.exists(properties.path))) {
+			if (
+				properties.path &&
+				!isIgnoredPath(properties.path) &&
+				!(await adapter.exists(properties.path))
+			) {
 				deletes.push([properties.path, "delete"]);
 			}
 		})
 	);
 
 	if (deletes.length) {
-		const deleteRequest = await t.drive.batchDelete(
-			deletes.map(([path]) => pathsToIds[path])
-		);
+		const idsToDelete = deletes
+			.map(([path]) => pathsToIds[path])
+			.filter((id): id is string => !!id);
+		const deleteRequest = idsToDelete.length
+			? await t.drive.batchDelete(idsToDelete)
+			: true;
 		if (!deleteRequest) {
 			return new Notice("An error occurred deleting Google Drive files.");
 		}
-		deletes.forEach(([path]) => delete t.settings.driveIdToPath[path]);
+		deletes.forEach(([path]) => {
+			const id = pathsToIds[path];
+			if (id) delete t.settings.driveIdToPath[id];
+		});
 	}
 
 	syncNotice.setMessage("Syncing (33%)");
@@ -473,12 +493,6 @@ export const push = async (t: ObsidianGoogleDrive) => {
 			t.settings.driveIdToPath[id] = path;
 			pathsToIds[path] = id;
 		})
-	);
-
-	await t.drive.updateFile(
-		pathsToIds[vault.configDir + "/plugins/google-drive-sync/data.json"],
-		new Blob([JSON.stringify(t.settings, null, 2)]),
-		{ modifiedTime: new Date().toISOString() }
 	);
 
 	t.settings.operations = {};

--- a/helpers/reset.ts
+++ b/helpers/reset.ts
@@ -1,6 +1,7 @@
 import ObsidianGoogleDrive from "main";
 import {
 	batchAsyncs,
+	cleanIgnoredOperations,
 	folderMimeType,
 	foldersToBatches,
 	getSyncMessage,
@@ -57,6 +58,7 @@ export const reset = async (t: ObsidianGoogleDrive) => {
 	const syncNotice = await t.startSync();
 
 	await pull(t, true);
+	cleanIgnoredOperations(t.settings.operations);
 
 	const { vault } = t.app;
 

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,10 @@
-import { checkConnection, getDriveClient } from "helpers/drive";
+import {
+	checkConnection,
+	cleanIgnoredOperations,
+	dropOperationsForPath,
+	getDriveClient,
+	isIgnoredPath,
+} from "helpers/drive";
 import { refreshAccessToken } from "helpers/ky";
 import { pull } from "helpers/pull";
 import { push } from "helpers/push";
@@ -141,6 +147,9 @@ export default class ObsidianGoogleDrive extends Plugin {
 			DEFAULT_SETTINGS,
 			await this.loadData()
 		);
+		if (cleanIgnoredOperations(this.settings.operations)) {
+			await this.saveSettings();
+		}
 	}
 
 	saveSettings() {
@@ -150,6 +159,11 @@ export default class ObsidianGoogleDrive extends Plugin {
 	debouncedSaveSettings = debounce(this.saveSettings.bind(this), 500, true);
 
 	handleCreate(file: TAbstractFile) {
+		if (isIgnoredPath(file.path)) {
+			dropOperationsForPath(this.settings.operations, file.path);
+			this.debouncedSaveSettings();
+			return;
+		}
 		if (this.settings.operations[file.path] === "delete") {
 			if (file instanceof TFile) {
 				this.settings.operations[file.path] = "modify";
@@ -163,6 +177,11 @@ export default class ObsidianGoogleDrive extends Plugin {
 	}
 
 	handleDelete(file: TAbstractFile) {
+		if (isIgnoredPath(file.path)) {
+			dropOperationsForPath(this.settings.operations, file.path);
+			this.debouncedSaveSettings();
+			return;
+		}
 		if (this.settings.operations[file.path] === "create") {
 			delete this.settings.operations[file.path];
 		} else {
@@ -172,6 +191,11 @@ export default class ObsidianGoogleDrive extends Plugin {
 	}
 
 	handleModify(file: TFile) {
+		if (isIgnoredPath(file.path)) {
+			dropOperationsForPath(this.settings.operations, file.path);
+			this.debouncedSaveSettings();
+			return;
+		}
 		const operation = this.settings.operations[file.path];
 		if (operation === "create" || operation === "modify") {
 			return;
@@ -181,8 +205,16 @@ export default class ObsidianGoogleDrive extends Plugin {
 	}
 
 	handleRename(file: TAbstractFile, oldPath: string) {
-		this.handleDelete({ ...file, path: oldPath });
-		this.handleCreate(file);
+		if (isIgnoredPath(oldPath)) {
+			dropOperationsForPath(this.settings.operations, oldPath);
+		} else {
+			this.handleDelete({ ...file, path: oldPath });
+		}
+		if (isIgnoredPath(file.path)) {
+			dropOperationsForPath(this.settings.operations, file.path);
+		} else {
+			this.handleCreate(file);
+		}
 		this.debouncedSaveSettings();
 	}
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+		"cleanup:operations": "node scripts/cleanup-operations.mjs",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},
 	"keywords": [],

--- a/scripts/cleanup-operations.mjs
+++ b/scripts/cleanup-operations.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const dataPath = process.argv.slice(2).find((arg) => !arg.startsWith("-"));
+if (!dataPath) {
+	console.error("Usage: node scripts/cleanup-operations.mjs path/to/data.json [--dry-run]");
+	process.exit(1);
+}
+
+const dryRun = process.argv.includes("--dry-run");
+const ignoredSegments = new Set([
+	".git",
+	".obsidian",
+	".trash",
+	".claude",
+	".claudian",
+	"node_modules",
+	"credentials",
+	"__pycache__",
+	"venv",
+	".venv",
+	"env",
+]);
+const sensitivePathPattern =
+	/(^|[\/._ -])(api[-_ ]?key|apikey|secret|token|credential)([\/._ -]|$)/i;
+
+const isIgnoredPath = (filePath) => {
+	const normalized = String(filePath || "").replace(/^\/+|\/+$/g, "");
+	if (!normalized) return false;
+	const segments = normalized.split("/");
+	return (
+		segments.some((segment) => ignoredSegments.has(segment)) ||
+		segments.some(
+			(segment) => segment === ".DS_Store" || /^\.env($|\.)/.test(segment)
+		) ||
+		sensitivePathPattern.test(normalized)
+	);
+};
+
+const data = JSON.parse(fs.readFileSync(dataPath, "utf8"));
+const operations =
+	data.operations && typeof data.operations === "object" && !Array.isArray(data.operations)
+		? data.operations
+		: {};
+const before = Object.keys(operations).length;
+let removed = 0;
+
+for (const operationPath of Object.keys(operations)) {
+	if (!isIgnoredPath(operationPath)) continue;
+	removed++;
+	if (!dryRun) delete operations[operationPath];
+}
+
+if (!dryRun && removed) {
+	fs.writeFileSync(path.resolve(dataPath), `${JSON.stringify(data, null, 2)}\n`);
+}
+
+console.log(
+	JSON.stringify(
+		{
+			dryRun,
+			before,
+			removed,
+			after: dryRun ? before : Object.keys(operations).length,
+		},
+		null,
+		2
+	)
+);


### PR DESCRIPTION
## Summary
- skip noisy/private paths before they enter pending operations
- avoid writing overlong full paths into Google Drive properties
- add cleanup logic and a small operations cleanup script

## Why
Large vaults can enqueue ignored folders like node_modules or credentials, and long nested paths can exceed Google Drive property value limits.

## Validation
- npm run build
- node scripts/cleanup-operations.mjs <sample-data>
