### PR TITLE
fix: allow re-authentication without emptying the vault

### DIFF
--- a/helpers/ky.ts
+++ b/helpers/ky.ts
@@ -57,6 +57,19 @@ export const refreshAccessToken = async (t: ObsidianGoogleDrive) => {
 				0
 			);
 		}
+
+		// Only treat the refresh token as invalid on a genuine auth failure.
+		// Transient errors (5xx, timeouts, rate limits) must NOT wipe the token,
+		// otherwise the user is forced to re-add it later. A revoked/expired
+		// refresh token surfaces as 400 (invalid_grant) / 401 / 403.
+		const status = e?.response?.status;
+		if (status !== 400 && status !== 401 && status !== 403) {
+			return new Notice(
+				"Could not fetch a new access token due to a temporary error. Your token is still saved — please try again in a moment or restart Obsidian.",
+				0
+			);
+		}
+
 		t.settings.refreshToken = "";
 		t.accessToken = {
 			token: "",

--- a/main.ts
+++ b/main.ts
@@ -346,30 +346,44 @@ class SettingsTab extends PluginSettingTab {
 							text.setValue("");
 							return;
 						}
-						if (
-							vault
-								.getAllLoadedFiles()
-								.filter(({ path }) => path !== "/").length > 0
-						) {
-							new Notice(
-								"Your current vault is not empty! If you want our plugin to handle the initial sync, you have to clear out the current vault. Check the readme or website for more details.",
-								0
-							);
-							return cancel();
-						}
 
-						const changesToken =
-							await this.plugin.drive.getChangesStartToken();
-						if (!changesToken) {
-							return new Notice(
-								"An error occurred fetching Google Drive changes token."
-							);
+						// If a changes token already exists, this vault has been
+						// set up before and the user is simply re-authenticating
+						// (e.g. after the refresh token was lost). In that case the
+						// local <-> Drive mapping in data.json is still intact, so we
+						// must NOT require an empty vault or redo the initial sync.
+						const isInitialSetup =
+							!this.plugin.settings.changesToken;
+
+						if (isInitialSetup) {
+							if (
+								vault
+									.getAllLoadedFiles()
+									.filter(({ path }) => path !== "/")
+									.length > 0
+							) {
+								new Notice(
+									"Your current vault is not empty! If you want our plugin to handle the initial sync, you have to clear out the current vault. Check the readme or website for more details.",
+									0
+								);
+								return cancel();
+							}
+
+							const changesToken =
+								await this.plugin.drive.getChangesStartToken();
+							if (!changesToken) {
+								return new Notice(
+									"An error occurred fetching Google Drive changes token."
+								);
+							}
+							this.plugin.settings.changesToken = changesToken;
 						}
-						this.plugin.settings.changesToken = changesToken;
 
 						await this.plugin.saveSettings();
 						new Notice(
-							"Refresh token saved! Reload Obsidian to activate sync.",
+							isInitialSetup
+								? "Refresh token saved! Reload Obsidian to activate sync."
+								: "Refresh token restored! Reload Obsidian to resume sync.",
 							0
 						);
 					});


### PR DESCRIPTION
## Problem

  When the refresh token is lost, re-entering it in settings forces the user to
  empty their entire vault — even though the local ↔ Drive mapping is still intact.
  On mobile (iOS/Android) emptying the vault is often impossible, leaving users stuck.

  This is reported in #4, #15 and #16.

  There are two underlying bugs:

  1. **The settings handler always treats a token entry as initial setup.**
     The empty-vault check and the initial `changesToken` fetch run every time a
     token is entered, so re-authentication is indistinguishable from first-time setup.

  2. **`refreshAccessToken` wipes the token on *any* failed request.**
     A transient server error (5xx, timeout, rate limit) makes the plugin assume the
     refresh token is invalid and clears it — this is the likely cause of the token
     "randomly disappearing" in #15.

  ## Fix

  - **`main.ts`**: only require an empty vault and fetch the initial changes token on
    genuine first-time setup (detected by the absence of `changesToken`). When a
    `changesToken` already exists the user is re-authenticating, so the token is simply
    restored and sync resumes — no vault clearing.
  - **`helpers/ky.ts`**: only clear the refresh token on a real auth failure
    (HTTP 400/401/403). Transient errors keep the token and ask the user to retry.

  `changesToken` and the rest of the sync state live in
  `.obsidian/plugins/google-drive-sync/data.json` and are never touched when the token
  is lost, so they are a reliable signal that setup already happened.

  ## Testing

  - `yarn build` (tsc typecheck + esbuild) passes.
  - Manually verified: re-entering the token on an already-synced, non-empty vault no
    longer prompts to empty it, and sync resumes from the existing mapping.

  Closes #4
  Closes #16
  Refs #15