### PR TITLE
fix: prevent duplicate vault root folders on concurrent creation

### DIFF
--- a/helpers/drive.ts
+++ b/helpers/drive.ts
@@ -167,7 +167,7 @@ export const getDriveClient = (t: ObsidianGoogleDrive) => {
 		) as FileMetadata[];
 	};
 
-	const getRootFolderId = async () => {
+	const fetchRootFolderId = async () => {
 		const files = await searchFiles(
 			{
 				matches: [{ properties: { obsidian: "vault" } }],
@@ -194,6 +194,18 @@ export const getDriveClient = (t: ObsidianGoogleDrive) => {
 		} else {
 			return files[0].id as string;
 		}
+	};
+
+	let rootFolderIdPromise: Promise<string | undefined> | null = null;
+
+	const getRootFolderId = () => {
+		if (!rootFolderIdPromise) {
+			rootFolderIdPromise = fetchRootFolderId().then((id) => {
+				if (!id) rootFolderIdPromise = null;
+				return id;
+			});
+		}
+		return rootFolderIdPromise;
 	};
 
 	const createFolder = async ({


### PR DESCRIPTION
I think this is the root cause of #42.

When you push a vault whose root folder doesn't exist on Drive yet, every top-level folder creation calls getRootFolderId at the same time (pushes run in batches of 10). They all see that there's no root folder yet and each one creates its own. On the first push of a vault with 15 top-level folders I ended up with 3 folders on Drive named after my vault, with the contents scattered between them.

This memoizes the promise so concurrent callers wait for the same lookup instead of racing each other. If the request fails, the cached promise is dropped so the next call retries.