### PR TITLE
fix: remove deleted files from driveIdToPath by id

### DIFF
--- a/helpers/push.ts
+++ b/helpers/push.ts
@@ -292,7 +292,10 @@ export const push = async (t: ObsidianGoogleDrive) => {
 		if (!deleteRequest) {
 			return new Notice("An error occurred deleting Google Drive files.");
 		}
-		deletes.forEach(([path]) => delete t.settings.driveIdToPath[path]);
+		deletes.forEach(([path]) => {
+			const id = pathsToIds[path];
+			if (id) delete t.settings.driveIdToPath[id];
+		});
 	}
 
 	syncNotice.setMessage("Syncing (33%)");


### PR DESCRIPTION
This probably explains #31 and #13.

driveIdToPath is keyed by Drive file id, but after a successful batch delete the push code does `delete t.settings.driveIdToPath[path]`, which never matches anything, so every deleted file stays in the map forever.

I noticed it after deleting about 300 files: the push itself went fine, but the map still contained all of them, and everything built from it afterwards (pathsToIds, the undo modal, pull mapping) kept seeing files that no longer exist.

Fixed by deleting the entry by id, using the pathsToIds map that is already built a few lines above.