### PR TITLE
feat: detect offline changes on startup

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -40,6 +40,7 @@ export default class ObsidianGoogleDrive extends Plugin {
 	drive = getDriveClient(this);
 	ribbonIcon: HTMLElement;
 	syncing: boolean;
+	lastSyncedAtOnLoad = 0;
 
 	async onload() {
 		const { vault } = this.app;
@@ -114,9 +115,12 @@ export default class ObsidianGoogleDrive extends Plugin {
 			this.app.workspace.on("quit", () => this.saveSettings())
 		);
 
-		this.app.workspace.onLayoutReady(() =>
-			this.registerEvent(vault.on("create", this.handleCreate.bind(this)))
-		);
+		this.app.workspace.onLayoutReady(() => {
+			this.registerEvent(
+				vault.on("create", this.handleCreate.bind(this))
+			);
+			this.reconcileOfflineChanges();
+		});
 		this.registerEvent(vault.on("delete", this.handleDelete.bind(this)));
 		this.registerEvent(vault.on("modify", this.handleModify.bind(this)));
 		this.registerEvent(vault.on("rename", this.handleRename.bind(this)));
@@ -135,12 +139,63 @@ export default class ObsidianGoogleDrive extends Plugin {
 		return this.saveSettings();
 	}
 
+	async reconcileOfflineChanges() {
+		for (let i = 0; i < 600 && this.syncing; i++) {
+			await new Promise((resolve) => setTimeout(resolve, 500));
+		}
+
+		const { operations, driveIdToPath } = this.settings;
+		const cloudPaths = new Set(Object.values(driveIdToPath));
+		if (!cloudPaths.size) return;
+
+		const { configDir } = this.app.vault;
+		const isConfigPath = (path: string) =>
+			path === configDir || path.startsWith(configDir + "/");
+
+		const localPaths = new Set<string>();
+		let changes = 0;
+
+		this.app.vault.getAllLoadedFiles().forEach((file) => {
+			const { path } = file;
+			if (path === "/" || isConfigPath(path)) return;
+			localPaths.add(path);
+			if (operations[path]) return;
+			if (!cloudPaths.has(path)) {
+				operations[path] = "create";
+				changes++;
+			} else if (
+				file instanceof TFile &&
+				file.stat.mtime > this.lastSyncedAtOnLoad
+			) {
+				operations[path] = "modify";
+				changes++;
+			}
+		});
+
+		for (const path of cloudPaths) {
+			if (isConfigPath(path) || localPaths.has(path) || operations[path]) {
+				continue;
+			}
+			if (!(await this.app.vault.adapter.exists(path))) {
+				operations[path] = "delete";
+				changes++;
+			}
+		}
+
+		if (!changes) return;
+		await this.saveSettings();
+		new Notice(
+			`Google Drive Sync: ${changes} offline change(s) queued for push.`
+		);
+	}
+
 	async loadSettings() {
 		this.settings = Object.assign(
 			{},
 			DEFAULT_SETTINGS,
 			await this.loadData()
 		);
+		this.lastSyncedAtOnLoad = this.settings.lastSyncedAt;
 	}
 
 	saveSettings() {


### PR DESCRIPTION
This should cover #22 and similar reports.

Right now the plugin only learns about local changes from vault events, so it only sees things that happen while Obsidian is running. If a file is created, edited or deleted while Obsidian is closed (git, scripts, another sync tool, or just Finder), it never gets into operations and push says there is nothing to push.

This PR adds a one-time check on startup, after onLayoutReady. It walks the vault and compares it against driveIdToPath: files that exist locally but not on Drive get queued as creates, files whose mtime is newer than the last sync get queued as modifies (the timestamp is captured at load time, before the startup pull updates it), and files that are in the map but gone from disk get queued as deletes. For deletes it double-checks with adapter.exists instead of trusting the file index, to avoid queueing a delete for a file Obsidian just has not indexed yet.

Everything found this way goes through the normal push flow and confirmation modal, so nothing is uploaded or deleted behind the user's back. The .obsidian folder is skipped since configs already have their own mtime-based handling, and if a sync is already running the check waits for it to finish first.

I have been running this on macOS: created 300 files from the terminal while Obsidian was closed and they all got picked up and pushed; deleted them the same way and got exactly the right set of deletes queued with no false positives; touching a single file while closed queues it as a modify.