### PR TITLE
feat: floating quick-access toolbar for sync commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This is an unofficial sync plugin for Obsidian, specifically for Google Drive.
 - Local file prioritization (automatically resolves conflicts)
 - Multiple vaults per Google account
 - Configuration syncing
+- Optional floating toolbar for quick access to sync commands
 
 ## New Devices
 
@@ -80,6 +81,7 @@ Note: Instructions are also on this plugin's homepage with images at [https://og
     - This will pull changes before pushing changes to Google Drive
 - You can enable `Automatically push changes` in the plugin settings to push one minute after the most recent local file change. This setting is disabled by default
 - If you want to set your local vault state to the Google Drive state, run the `Reset local vault to Google Drive` command
+- You can enable `Floating toolbar` in the plugin settings to show a draggable button on the right edge of the app. Clicking it expands a menu of quick-access sync actions (Push, Pull, Fix paths, Reset). Choose which actions appear under `Toolbar actions`; at least one must stay enabled. This setting is disabled by default
 - If you mess with the vault's files while Obsidian is closed, try to revert any of the changes you made
 
 ## Multiple Vaults

--- a/main.ts
+++ b/main.ts
@@ -4,16 +4,27 @@ import { pull } from './helpers/pull';
 import { push } from './helpers/push';
 import { reset } from './helpers/reset';
 import {
+	addIcon,
 	App,
 	debounce,
 	Notice,
 	Plugin,
 	PluginSettingTab,
+	setIcon,
 	type SettingDefinitionItem,
 	TAbstractFile,
 	TFile,
 } from 'obsidian';
 import { fixDrivePath } from './helpers/fix_drive_path';
+
+// Lucide "refresh-cw" scaled from its 24px grid to Obsidian's 100px icon grid.
+const OGD_SYNC_ICON =
+	'<g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" transform="scale(4.1667)">' +
+	'<path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />' +
+	'<path d="M21 3v5h-5" />' +
+	'<path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />' +
+	'<path d="M3 21v-5h5" />' +
+	'</g>';
 
 interface PluginSettings {
 	refreshToken: string;
@@ -26,6 +37,11 @@ interface PluginSettings {
 	rootFolderId: string;
 	lastSyncedAt: number;
 	changesToken: string;
+	enableFloatingToolbar: boolean;
+	toolbarPush: boolean;
+	toolbarPull: boolean;
+	toolbarFix: boolean;
+	toolbarReset: boolean;
 }
 
 const DEFAULT_SETTINGS: PluginSettings = {
@@ -39,6 +55,11 @@ const DEFAULT_SETTINGS: PluginSettings = {
 	rootFolderId: '',
 	lastSyncedAt: 0,
 	changesToken: '',
+	enableFloatingToolbar: false,
+	toolbarPush: true,
+	toolbarPull: false,
+	toolbarFix: false,
+	toolbarReset: false,
 };
 
 export default class ObsidianGoogleDrive extends Plugin {
@@ -51,6 +72,8 @@ export default class ObsidianGoogleDrive extends Plugin {
 	ribbonIcon!: HTMLElement;
 	syncing!: boolean;
 	autoPushTimer?: number;
+	toolbarEl?: HTMLElement;
+	toolbarOutsideClick?: (event: MouseEvent) => void;
 
 	async onload() {
 		const { vault } = this.app;
@@ -100,6 +123,8 @@ export default class ObsidianGoogleDrive extends Plugin {
 			callback: () => fixDrivePath(this),
 		});
 
+		if (this.settings.enableFloatingToolbar) this.createFloatingToolbar();
+
 		this.registerEvent(
 			this.app.workspace.on('quit', () => this.saveSettings()),
 		);
@@ -134,8 +159,142 @@ export default class ObsidianGoogleDrive extends Plugin {
 
 	onunload() {
 		this.clearAutoPushTimer();
+		this.removeFloatingToolbar();
 		void this.saveSettings();
 		return;
+	}
+
+	toolbarActions(): [string, string, () => void][] {
+		const all: [keyof PluginSettings, string, string, () => void][] = [
+			['toolbarPush', 'upload-cloud', 'Push to Google Drive', () =>
+				void push(this)],
+			['toolbarPull', 'download-cloud', 'Pull from Google Drive', () =>
+				void pull(this)],
+			['toolbarFix', 'wrench', 'Fix Google Drive paths', () =>
+				void fixDrivePath(this)],
+			['toolbarReset', 'rotate-ccw', 'Reset local vault to Google Drive', () =>
+				void reset(this)],
+		];
+		return all
+			.filter(([key]) => this.settings[key])
+			.map(([, icon, label, action]) => [icon, label, action]);
+	}
+
+	setFloatingToolbarOpen(open: boolean) {
+		const container = this.toolbarEl;
+		if (!container) return;
+		container.toggleClass('is-open', open);
+		const launcher = container.querySelector<HTMLElement>(
+			'.ogd-fab-launcher',
+		);
+		if (launcher) setIcon(launcher, open ? 'x' : 'ogd-sync');
+		if (open) this.updateFloatingToolbarDirection();
+	}
+
+	// Open below instead of above when the button sits near the top of the screen.
+	updateFloatingToolbarDirection() {
+		const container = this.toolbarEl;
+		if (!container) return;
+		const top = container.getBoundingClientRect().top;
+		container.toggleClass('open-below', top < window.innerHeight * 0.35);
+	}
+
+	createFloatingToolbar() {
+		if (this.toolbarEl) return;
+
+		const actions = this.toolbarActions();
+		if (!actions.length) return;
+
+		addIcon('ogd-sync', OGD_SYNC_ICON);
+
+		const container = document.body.createDiv('ogd-fab');
+
+		const menu = container.createDiv('ogd-fab-menu');
+		for (const [icon, label, action] of actions) {
+			const item = menu.createEl('button', {
+				cls: 'ogd-fab-item',
+				attr: { 'aria-label': label },
+			});
+			setIcon(item.createSpan('ogd-fab-item-icon'), icon);
+			item.createSpan({ cls: 'ogd-fab-item-label', text: label });
+			item.addEventListener('click', () => {
+				if (this.syncing) return;
+				action();
+				this.setFloatingToolbarOpen(false);
+			});
+		}
+
+		const launcher = container.createEl('button', {
+			cls: 'ogd-fab-launcher',
+			attr: { 'aria-label': 'Google Drive sync' },
+		});
+		setIcon(launcher, 'ogd-sync');
+		this.makeFloatingToolbarDraggable(container, launcher);
+
+		this.toolbarOutsideClick = (event) => {
+			if (!container.contains(event.target as Node)) {
+				this.setFloatingToolbarOpen(false);
+			}
+		};
+		document.addEventListener('click', this.toolbarOutsideClick, true);
+
+		document.body.appendChild(container);
+		container.style.top = `${Math.round(window.innerHeight * 0.4)}px`;
+		this.updateFloatingToolbarDirection();
+
+		this.toolbarEl = container;
+	}
+
+	makeFloatingToolbarDraggable(container: HTMLElement, handle: HTMLElement) {
+		let startY = 0;
+		let startTop = 0;
+		let dragging = false;
+		let moved = false;
+
+		handle.addEventListener('pointerdown', (event) => {
+			dragging = true;
+			moved = false;
+			startY = event.clientY;
+			startTop = container.getBoundingClientRect().top;
+			handle.setPointerCapture(event.pointerId);
+		});
+		handle.addEventListener('pointermove', (event) => {
+			if (!dragging) return;
+			const delta = event.clientY - startY;
+			if (Math.abs(delta) > 4) moved = true;
+			const max = Math.max(8, window.innerHeight - container.offsetHeight - 8);
+			container.style.top = `${Math.min(Math.max(8, startTop + delta), max)}px`;
+			this.updateFloatingToolbarDirection();
+		});
+		const end = (event: PointerEvent) => {
+			if (!dragging) return;
+			dragging = false;
+			try {
+				handle.releasePointerCapture(event.pointerId);
+			} catch {
+				/* pointer already released */
+			}
+			// A press without movement is a click: toggle the menu.
+			if (!moved) {
+				this.setFloatingToolbarOpen(!container.hasClass('is-open'));
+			}
+		};
+		handle.addEventListener('pointerup', end);
+		handle.addEventListener('pointercancel', end);
+	}
+
+	removeFloatingToolbar() {
+		if (this.toolbarOutsideClick) {
+			document.removeEventListener('click', this.toolbarOutsideClick, true);
+			this.toolbarOutsideClick = undefined;
+		}
+		this.toolbarEl?.remove();
+		this.toolbarEl = undefined;
+	}
+
+	refreshFloatingToolbar() {
+		this.removeFloatingToolbar();
+		if (this.settings.enableFloatingToolbar) this.createFloatingToolbar();
 	}
 
 	async loadSettings() {
@@ -433,6 +592,59 @@ class SettingsTab extends PluginSettingTab {
 				},
 			},
 			{
+				name: 'Floating toolbar',
+				desc: 'Show a collapsible quick-access launcher on the right edge. Tap it to reveal the actions below.',
+				control: {
+					type: 'toggle',
+					key: 'enableFloatingToolbar',
+					defaultValue: false,
+				},
+			},
+			{
+				type: 'group',
+				heading: 'Toolbar actions',
+				cls: 'ogd-toolbar-actions',
+				visible: () => this.plugin.settings.enableFloatingToolbar,
+				items: [
+					{
+						name: 'Push',
+						desc: 'Push to Google Drive.',
+						control: {
+							type: 'toggle',
+							key: 'toolbarPush',
+							defaultValue: true,
+						},
+					},
+					{
+						name: 'Pull',
+						desc: 'Pull from Google Drive.',
+						control: {
+							type: 'toggle',
+							key: 'toolbarPull',
+							defaultValue: false,
+						},
+					},
+					{
+						name: 'Fix paths',
+						desc: 'Fix Google Drive paths.',
+						control: {
+							type: 'toggle',
+							key: 'toolbarFix',
+							defaultValue: false,
+						},
+					},
+					{
+						name: 'Reset',
+						desc: 'Reset local vault to Google Drive.',
+						control: {
+							type: 'toggle',
+							key: 'toolbarReset',
+							defaultValue: false,
+						},
+					},
+				],
+			},
+			{
 				name: 'Access token endpoint',
 				desc: 'Service used to exchange the refresh token for a Google access token. The refresh token is sent to this URL. This is just so you can self-host the access token refresher. The code to host the website is available at https://github.com/RichardX366/Obsidian-Google-Drive-website. Defaults to my hosted service at https://ogd-server.richardxiong.com/api/access.',
 				control: {
@@ -479,6 +691,29 @@ class SettingsTab extends PluginSettingTab {
 		if (key === 'autoPush') {
 			if (value) this.plugin.resumeAutoPushIfNeeded();
 			else this.plugin.clearAutoPushTimer();
+		}
+		if (key === 'enableFloatingToolbar') {
+			this.plugin.refreshFloatingToolbar();
+			this.update();
+			return;
+		}
+
+		const actionKeys: (keyof PluginSettings)[] = [
+			'toolbarPush',
+			'toolbarPull',
+			'toolbarFix',
+			'toolbarReset',
+		];
+		if (actionKeys.includes(key as keyof PluginSettings)) {
+			if (!actionKeys.some((k) => this.plugin.settings[k])) {
+				// Don't let the user disable the last remaining action.
+				(this.plugin.settings[key as keyof PluginSettings] as boolean) =
+					true;
+				await this.plugin.saveSettings();
+				this.update();
+				new Notice('Keep at least one toolbar action enabled.');
+			}
+			this.plugin.refreshFloatingToolbar();
 		}
 	}
 }

--- a/styles.css
+++ b/styles.css
@@ -56,3 +56,113 @@
 	color: var(--text-error);
 	font-weight: bolder;
 }
+
+/* Draggable quick-access toolbar pinned to the right edge. */
+.ogd-fab {
+	position: fixed;
+	right: 0;
+	z-index: var(--layer-notice);
+}
+
+.ogd-fab-launcher {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: var(--size-4-8);
+	height: var(--size-4-12);
+	padding: 0;
+	color: var(--text-normal);
+	background-color: var(--interactive-normal);
+	border: var(--border-width) solid var(--background-modifier-border);
+	border-right: none;
+	border-radius: var(--radius-l) 0 0 var(--radius-l);
+	box-shadow: var(--shadow-s);
+	cursor: grab;
+	touch-action: none;
+}
+
+.ogd-fab-launcher:hover {
+	background-color: var(--interactive-hover);
+}
+
+.ogd-fab-launcher:active {
+	cursor: grabbing;
+}
+
+.ogd-fab-launcher .svg-icon {
+	width: var(--icon-m);
+	height: var(--icon-m);
+}
+
+/* Absolute so opening the menu doesn't shift the button. */
+.ogd-fab-menu {
+	position: absolute;
+	right: 0;
+	bottom: calc(100% + var(--size-2-2));
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	gap: var(--size-2-2);
+	transition:
+		opacity 150ms ease,
+		transform 150ms ease;
+}
+
+.ogd-fab.open-below .ogd-fab-menu {
+	bottom: auto;
+	top: calc(100% + var(--size-2-2));
+}
+
+/* Collapsed: slide the menu off the right edge. */
+.ogd-fab:not(.is-open) .ogd-fab-menu {
+	opacity: 0;
+	transform: translateX(100%);
+	visibility: hidden;
+	pointer-events: none;
+}
+
+.ogd-fab-item {
+	display: flex;
+	align-items: center;
+	gap: var(--size-2-3);
+	height: var(--size-4-12);
+	padding: 0 var(--size-4-4);
+	color: var(--text-normal);
+	background-color: var(--background-secondary);
+	border: var(--border-width) solid var(--background-modifier-border);
+	border-right: none;
+	border-radius: var(--radius-m) 0 0 var(--radius-m);
+	box-shadow: var(--shadow-s);
+	font-size: var(--font-ui-small);
+	white-space: nowrap;
+	cursor: pointer;
+}
+
+.ogd-fab-item:hover {
+	color: var(--interactive-accent);
+	background-color: var(--background-modifier-hover);
+}
+
+.ogd-fab-item-icon {
+	display: inline-flex;
+}
+
+.ogd-fab-item-icon .svg-icon {
+	width: var(--icon-s);
+	height: var(--icon-s);
+}
+
+/* Indent the settings action toggles so they read as sub-points. */
+.ogd-toolbar-actions {
+	margin-left: var(--size-4-4);
+	padding-left: var(--size-4-3);
+	border-left: var(--border-width) solid var(--background-modifier-border);
+}
+
+@media (max-width: 400px) {
+	.ogd-fab-item {
+		height: var(--size-4-10);
+		padding: 0 var(--size-4-3);
+		font-size: var(--font-ui-smaller);
+	}
+}

--- a/tests/floating_toolbar.test.ts
+++ b/tests/floating_toolbar.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.stubGlobal('window', globalThis);
+
+vi.mock('obsidian', () => {
+	class TAbstractFile {
+		path: string;
+		constructor(path: string) {
+			this.path = path;
+		}
+	}
+	class TFile extends TAbstractFile {}
+	return {
+		App: class {},
+		Menu: class {},
+		Modal: class {},
+		Notice: class {},
+		Plugin: class {},
+		PluginSettingTab: class {},
+		Setting: class {},
+		TAbstractFile,
+		TFile,
+		TFolder: class extends TAbstractFile {},
+		addIcon: vi.fn(),
+		debounce: (callback: unknown) => callback,
+		requestUrl: vi.fn(),
+		setIcon: vi.fn(),
+	};
+});
+
+import ObsidianGoogleDrive from '../main';
+
+const createPlugin = (actions: Record<string, boolean>) =>
+	Object.assign(Object.create(ObsidianGoogleDrive.prototype), {
+		settings: {
+			toolbarPush: false,
+			toolbarPull: false,
+			toolbarFix: false,
+			toolbarReset: false,
+			...actions,
+		},
+	}) as ObsidianGoogleDrive;
+
+describe('ObsidianGoogleDrive floating toolbar actions', () => {
+	it('includes only the enabled actions, in order', () => {
+		const plugin = createPlugin({ toolbarReset: true, toolbarPush: true });
+
+		expect(plugin.toolbarActions().map(([, label]) => label)).toEqual([
+			'Push to Google Drive',
+			'Reset local vault to Google Drive',
+		]);
+	});
+
+	it('maps an enabled action to its icon and label', () => {
+		const plugin = createPlugin({ toolbarPull: true });
+
+		expect(plugin.toolbarActions()).toEqual([
+			['download-cloud', 'Pull from Google Drive', expect.any(Function)],
+		]);
+	});
+
+	it('returns nothing when every action is disabled', () => {
+		expect(createPlugin({}).toolbarActions()).toEqual([]);
+	});
+});


### PR DESCRIPTION
Closes #48

## Summary

Adds an optional **floating toolbar** for quick access to the sync commands
without opening the command palette. It's a single draggable button pinned to
the right edge of the app that expands into a menu of sync actions.

Disabled by default — fully opt-in.

## Screenshots

| Collapsed | Expanded menu | Settings |
|---|---|---|
| <img width="360" alt="expanded menu" src="https://github.com/user-attachments/assets/bd19b196-fb98-45dc-85b3-0632e071ebed" /> | <img width="360" alt="collapsed button" src="https://github.com/user-attachments/assets/31e5d51a-9aad-4de5-918d-e540f197f196" /> | <img width="360" alt="settings with toolbar action toggles" src="https://github.com/user-attachments/assets/9b99e64b-2e73-435c-9e06-0cad8e6180e4" /> |

## What it does

- **Toggle in settings** (`Floating toolbar`) shows/hides it live, no reload needed.
- **Draggable button** on the right edge — drag it vertically to reposition; a
  press without movement opens/closes the menu.
- **Expandable menu** with the four sync actions: Push, Pull, Fix paths, Reset.
  The button shows the sync icon when collapsed and a cross when open.
- **Opens away from the edge** — if dragged near the top, the menu opens below
  so it never runs off-screen.
- **Choose which actions appear** under a `Toolbar actions` sub-group (shown only
  when the toolbar is enabled). At least one action must stay enabled; default is
  **Push**.
- Buttons call the existing `push` / `pull` / `fixDrivePath` / `reset` helpers and
  no-op while a sync is in progress.

## Implementation notes

- Native styling throughout: Obsidian CSS variables (`--interactive-normal`,
  `--background-secondary`, `--background-modifier-border`, etc.), `setIcon` for
  Lucide icons, and `aria-label` tooltips.
- The launcher icon is registered via `addIcon('ogd-sync', …)` — a Lucide
  `refresh-cw` scaled to Obsidian's icon grid, so it recolors with the theme.
- Responsive down to mobile widths; drag works with touch (`touch-action: none`).
- Cleanly torn down on unload and when disabled (element removed, document
  listener detached) — no leaks.

## Tests

- Added `tests/floating_toolbar.test.ts` covering action selection (only enabled
  actions returned, in order; icon/label mapping; empty when all disabled),
  matching the existing test style.
- `npm test` → all passing. `npm run build` and `npm run lint` clean.

## Docs

- README: added a Features bullet and a Use entry describing the setting.

## Changes

- `main.ts` — setting + toolbar create/drag/toggle/teardown, per-action toggles,
  at-least-one enforcement
- `styles.css` — toolbar styles
- `tests/floating_toolbar.test.ts` — action-selection tests
- `README.md` — docs